### PR TITLE
[fix/#61-update-experience] 경력 상세 내용 리스트로 변경

### DIFF
--- a/src/main/java/com/coastee/server/global/dto/UpdateRequest.java
+++ b/src/main/java/com/coastee/server/global/dto/UpdateRequest.java
@@ -1,0 +1,13 @@
+package com.coastee.server.global.dto;
+
+public abstract class UpdateRequest {
+
+    protected  <T> T getOrDefault(
+            final T newValue,
+            final T defaultValue
+    ) {
+        if (newValue != null)
+            return newValue;
+        return defaultValue;
+    }
+}

--- a/src/main/java/com/coastee/server/user/domain/Experience.java
+++ b/src/main/java/com/coastee/server/user/domain/Experience.java
@@ -7,9 +7,13 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.Hibernate;
+import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.annotations.SQLRestriction;
+import org.hibernate.type.SqlTypes;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 import static com.coastee.server.global.apipayload.code.status.ErrorStatus._INVALID_AUTHORITY;
@@ -31,7 +35,8 @@ public class Experience extends BaseEntity {
 
     private String title;
 
-    private String content;
+    @JdbcTypeCode(SqlTypes.ARRAY)
+    private List<String> contentList = new ArrayList<>();
 
     @Embedded
     private Period period = new Period();
@@ -39,12 +44,12 @@ public class Experience extends BaseEntity {
     public Experience(
             final User user,
             final String title,
-            final String content,
+            final List<String> contentList,
             final Period period
     ) {
         this.user = user;
         this.title = title;
-        this.content = content;
+        this.contentList = contentList;
         this.period = period;
     }
 
@@ -64,8 +69,8 @@ public class Experience extends BaseEntity {
         this.title = title;
     }
 
-    public void updateContent(final String content) {
-        this.content = content;
+    public void updateContentList(final List<String> contentList) {
+        this.contentList = contentList;
     }
 
     public void updatePeriod(

--- a/src/main/java/com/coastee/server/user/dto/ExperienceElement.java
+++ b/src/main/java/com/coastee/server/user/dto/ExperienceElement.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static com.coastee.server.global.domain.Constant.CURRENT_DATE;
 import static lombok.AccessLevel.PROTECTED;
@@ -17,14 +18,14 @@ import static lombok.AccessLevel.PROTECTED;
 public class ExperienceElement {
     private Long id;
     private String title;
-    private String content;
+    private List<String> contentList;
     private LocalDateTime startDate;
     private LocalDateTime endDate;
 
     public ExperienceElement(final Experience experience) {
         this.id = experience.getId();
         this.title = experience.getTitle();
-        this.content = experience.getContent();
+        this.contentList = experience.getContentList();
         Period period = experience.getPeriod();
         this.startDate = period.getStartDate();
         this.endDate = period.getEndDate();

--- a/src/main/java/com/coastee/server/user/dto/request/ExperienceCreateRequest.java
+++ b/src/main/java/com/coastee/server/user/dto/request/ExperienceCreateRequest.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static com.coastee.server.global.domain.Constant.CURRENT_DATE;
 import static lombok.AccessLevel.PROTECTED;
@@ -18,11 +19,12 @@ import static lombok.AccessLevel.PROTECTED;
 @NoArgsConstructor(access = PROTECTED)
 @AllArgsConstructor
 public class ExperienceCreateRequest {
-    @Size(min = 1)
+    @Size(min = 1, max = 30, message = "경력 제목은 최소 1자 이상, 최대 30자 이하까지 설정할 수 있습니다.")
     @NotNull(message = "제목은 필수로 입력해야 합니다.")
     private String title;
 
-    private String content;
+    @Size(max = 5, message = "세부사항은 최대 5개까지 설정할 수 있습니다.")
+    private List<@Size(max = 30, message = "세부사항은 최대 30자까지 설정할 수 있습니다.") String> contentList;
 
     @NotNull(message = "시작 날짜는 필수로 입력해야 합니다.")
     private LocalDateTime startDate;
@@ -33,7 +35,7 @@ public class ExperienceCreateRequest {
         return new Experience(
                 user,
                 title,
-                content,
+                contentList,
                 new Period(startDate, getEndDate())
         );
     }

--- a/src/main/java/com/coastee/server/user/dto/request/ExperienceUpdateRequest.java
+++ b/src/main/java/com/coastee/server/user/dto/request/ExperienceUpdateRequest.java
@@ -1,6 +1,7 @@
 package com.coastee.server.user.dto.request;
 
 import com.coastee.server.chatroom.domain.Period;
+import com.coastee.server.global.dto.UpdateRequest;
 import com.coastee.server.user.domain.Experience;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
@@ -8,17 +9,19 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static lombok.AccessLevel.PROTECTED;
 
 @Getter
 @NoArgsConstructor(access = PROTECTED)
 @AllArgsConstructor
-public class ExperienceUpdateRequest {
-    @Size(min = 1)
+public class ExperienceUpdateRequest extends UpdateRequest {
+    @Size(min = 1, max = 30, message = "경력 제목은 최소 1자 이상, 최대 30자 이하까지 설정할 수 있습니다.")
     private String title;
 
-    private String content;
+    @Size(max = 5, message = "세부사항은 최대 5개까지 설정할 수 있습니다.")
+    private List<@Size(max = 30, message = "세부사항은 최대 30자까지 설정할 수 있습니다.") String> contentList;
 
     private LocalDateTime startDate;
 
@@ -26,18 +29,9 @@ public class ExperienceUpdateRequest {
 
     public void validateNullValue(final Experience experience) {
         this.title = getOrDefault(this.title, experience.getTitle());
-        this.content = getOrDefault(this.content, experience.getContent());
+        this.contentList = getOrDefault(this.contentList, experience.getContentList());
         Period period = experience.getPeriod();
         this.startDate = getOrDefault(this.startDate, period.getStartDate());
         this.endDate = getOrDefault(this.endDate, period.getEndDate());
-    }
-
-    private <T> T getOrDefault(
-            final T newValue,
-            final T defaultValue
-    ) {
-        if (newValue != null)
-            return newValue;
-        return defaultValue;
     }
 }

--- a/src/main/java/com/coastee/server/user/dto/request/UserUpdateRequest.java
+++ b/src/main/java/com/coastee/server/user/dto/request/UserUpdateRequest.java
@@ -1,5 +1,6 @@
 package com.coastee.server.user.dto.request;
 
+import com.coastee.server.global.dto.UpdateRequest;
 import com.coastee.server.user.domain.User;
 import com.coastee.server.user.domain.UserIntro;
 import jakarta.validation.constraints.Size;
@@ -14,7 +15,7 @@ import static lombok.AccessLevel.PROTECTED;
 @Getter
 @NoArgsConstructor(access = PROTECTED)
 @AllArgsConstructor
-public class UserUpdateRequest {
+public class UserUpdateRequest extends UpdateRequest {
     @Size(min = 2, max = 10, message = "닉네임은 최소 2자 이상, 10자 이하로 설정할 수 있습니다.")
     private String nickname;
 
@@ -40,14 +41,5 @@ public class UserUpdateRequest {
         this.job = getOrDefault(this.job, userIntro.getJob());
         this.expYears = getOrDefault(this.expYears, userIntro.getExpYears());
         this.bio = getOrDefault(this.bio, user.getBio());
-    }
-
-    private <T> T getOrDefault(
-            final T newValue,
-            final T defaultValue
-    ) {
-        if (newValue != null)
-            return newValue;
-        return defaultValue;
     }
 }

--- a/src/main/java/com/coastee/server/user/service/ExperienceService.java
+++ b/src/main/java/com/coastee/server/user/service/ExperienceService.java
@@ -44,7 +44,7 @@ public class ExperienceService {
             final ExperienceUpdateRequest request
     ) {
         experience.updateTitle(request.getTitle());
-        experience.updateContent(request.getContent());
+        experience.updateContentList(request.getContentList());
         experience.updatePeriod(request.getStartDate(), request.getEndDate());
     }
 }

--- a/src/test/java/com/coastee/server/fixture/ExperienceFixture.java
+++ b/src/test/java/com/coastee/server/fixture/ExperienceFixture.java
@@ -13,7 +13,7 @@ public class ExperienceFixture {
         return new Experience(
                 user,
                 "숙명 기업 인턴",
-                "인턴십 과정을을 진행하여 000 결과에 기여하였습니다.",
+                List.of("인턴십 과정을을 진행하여 000 결과에 기여하였습니다."),
                 new Period(LocalDateTime.now().minusYears(1L), LocalDateTime.now())
         );
     }
@@ -23,20 +23,20 @@ public class ExperienceFixture {
                 new Experience(
                         user,
                         "B 기업 개발팀장",
-                        "000 결과에 기여하였습니다.",
+                        List.of("000 개발팀장", "000 결과에 기여하였습니다."),
                         new Period(LocalDateTime.now().minusYears(1L), LocalDateTime.now())
                 ),
                 new Experience(
                         user,
                         "A 기업 개발팀",
-                        "000 결과에 기여하였습니다.",
-                        new Period(LocalDateTime.now().minusYears(1L), LocalDateTime.now())
+                        List.of("000 개발팀", "000 결과에 기여하였습니다."),
+                        new Period(LocalDateTime.now().minusYears(2L), LocalDateTime.now().minusYears(1L))
                 ),
                 new Experience(
                         user,
                         "숙명 기업 인턴",
-                        "인턴십 과정을 진행하여 000 결과에 기여하였습니다.",
-                        new Period(LocalDateTime.now().minusYears(1L), LocalDateTime.now())
+                        List.of("000 개발팀 인턴", "인턴십 과정을 진행하여 000 결과에 기여하였습니다."),
+                        new Period(LocalDateTime.now().minusYears(3L), LocalDateTime.now().minusYears(2L))
                 )
         );
     }

--- a/src/test/java/com/coastee/server/user/controller/ExperienceControllerTest.java
+++ b/src/test/java/com/coastee/server/user/controller/ExperienceControllerTest.java
@@ -12,6 +12,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -85,7 +86,7 @@ class ExperienceControllerTest extends ControllerTest {
 
         ExperienceUpdateRequest request = new ExperienceUpdateRequest(
                 "title",
-                "content",
+                List.of("000 개발에 참여하였습니다.", "000 결과에 기여하였습니다."),
                 LocalDateTime.now().minusMonths(5),
                 LocalDateTime.now()
         );
@@ -106,7 +107,7 @@ class ExperienceControllerTest extends ControllerTest {
                                 ),
                                 requestFields(
                                         fieldWithPath("title").type(STRING).description("제목"),
-                                        fieldWithPath("content").type(STRING).description("내용"),
+                                        fieldWithPath("content").type(ARRAY).description("내용"),
                                         fieldWithPath("startDate").type(ARRAY).description("시작기간"),
                                         fieldWithPath("endDate").type(ARRAY).description("끝나는기간 : null로 전달시 현재까지 진행되는 경력으로 간주됨.")
                                 ),

--- a/src/test/java/com/coastee/server/user/controller/ExperienceControllerTest.java
+++ b/src/test/java/com/coastee/server/user/controller/ExperienceControllerTest.java
@@ -43,7 +43,7 @@ class ExperienceControllerTest extends ControllerTest {
 
         ExperienceCreateRequest request = new ExperienceCreateRequest(
                 "title",
-                "content",
+                List.of("000 개발에 참여하였습니다.", "000 결과에 기여하였습니다."),
                 LocalDateTime.now().minusMonths(5),
                 LocalDateTime.now()
         );
@@ -63,7 +63,7 @@ class ExperienceControllerTest extends ControllerTest {
                                 ),
                                 requestFields(
                                         fieldWithPath("title").type(STRING).description("제목"),
-                                        fieldWithPath("content").type(STRING).description("내용"),
+                                        fieldWithPath("contentList").type(ARRAY).description("내용 리스트"),
                                         fieldWithPath("startDate").type(ARRAY).description("시작기간"),
                                         fieldWithPath("endDate").type(ARRAY).description("끝나는기간 : null로 전달시 현재까지 진행되는 경력으로 간주됨.")
                                 ),
@@ -107,7 +107,7 @@ class ExperienceControllerTest extends ControllerTest {
                                 ),
                                 requestFields(
                                         fieldWithPath("title").type(STRING).description("제목"),
-                                        fieldWithPath("content").type(ARRAY).description("내용"),
+                                        fieldWithPath("contentList").type(ARRAY).description("내용"),
                                         fieldWithPath("startDate").type(ARRAY).description("시작기간"),
                                         fieldWithPath("endDate").type(ARRAY).description("끝나는기간 : null로 전달시 현재까지 진행되는 경력으로 간주됨.")
                                 ),

--- a/src/test/java/com/coastee/server/user/controller/UserControllerTest.java
+++ b/src/test/java/com/coastee/server/user/controller/UserControllerTest.java
@@ -92,7 +92,7 @@ class UserControllerTest extends ControllerTest {
                                         fieldWithPath("result.experience.experienceList").type(ARRAY).description("경력 리스트"),
                                         fieldWithPath("result.experience.experienceList[].id").type(NUMBER).description("경력 아이디"),
                                         fieldWithPath("result.experience.experienceList[].title").type(STRING).description("제목"),
-                                        fieldWithPath("result.experience.experienceList[].content").type(STRING).description("상세 내용"),
+                                        fieldWithPath("result.experience.experienceList[].contentList").type(ARRAY).description("상세 내용"),
                                         fieldWithPath("result.experience.experienceList[].startDate").type(ARRAY).description("시작날짜"),
                                         fieldWithPath("result.experience.experienceList[].endDate").type(ARRAY).description("종료날짜 : 현재까지 진행되는 경력일 경우 null로 전달됨.")
                                 )


### PR DESCRIPTION
## 📒 개요

content를 string list 형태의 contentList로 변경합니다.

## 📍 Issue 번호

- #61 

## 🛠️ 작업사항

- [x] 경력 리스트로 필드 변경
- [x] 경력 생성/수정 dto 및 api 스펙 변경
