### PR TITLE
[fix/#89-hash-tag-search] 해시태그 검색

### DIFF
--- a/src/docs/asciidoc/hashtag.adoc
+++ b/src/docs/asciidoc/hashtag.adoc
@@ -1,0 +1,33 @@
+= HashTag API
+coaster server
+:doctype: book
+:icons: font
+:source-highlighter: highlishtjs
+:toc: left
+:toclevels: 4
+:sectlinks:
+
+ifndef::snippets[]
+:snippets: ./build/generated-snippets
+endif::[]
+
+== `GET` Find HashTag
+
+=== Request
+```
+/api/v1/servers/{serverId}/tags
+```
+include::{snippets}/find-hashtag/curl-request.adoc[]
+
+==== header
+include::{snippets}/find-hashtag/request-headers.adoc[]
+
+==== path parameter
+include::{snippets}/find-hashtag/path-parameters.adoc[]
+
+==== query parameter
+include::{snippets}/find-hashtag/query-parameters.adoc[]
+
+=== Response
+include::{snippets}/find-hashtag/response-body.adoc[]
+include::{snippets}/find-hashtag/response-fields.adoc[]

--- a/src/main/java/com/coastee/server/hashtag/controller/HashTagController.java
+++ b/src/main/java/com/coastee/server/hashtag/controller/HashTagController.java
@@ -1,0 +1,32 @@
+package com.coastee.server.hashtag.controller;
+
+import com.coastee.server.global.apipayload.ApiResponse;
+import com.coastee.server.hashtag.dto.HashTagElements;
+import com.coastee.server.hashtag.facade.HashTagFacade;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.*;
+
+import static com.coastee.server.global.domain.Constant.DEFAULT_PAGING_SIZE;
+
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/servers/{serverId}/tags")
+public class HashTagController {
+    private HashTagFacade hashTagFacade;
+
+    @GetMapping("")
+    public ApiResponse<HashTagElements> findAll(
+            @PathVariable final Long serverId,
+            @RequestParam(value = "keyword", required = false) final String keyword,
+            @PageableDefault(DEFAULT_PAGING_SIZE) final Pageable pageable
+    ) {
+        return ApiResponse.onSuccess(hashTagFacade.findWithConditions(
+                serverId,
+                keyword,
+                pageable
+        ));
+    }
+}

--- a/src/main/java/com/coastee/server/hashtag/controller/HashTagController.java
+++ b/src/main/java/com/coastee/server/hashtag/controller/HashTagController.java
@@ -15,7 +15,7 @@ import static com.coastee.server.global.domain.Constant.DEFAULT_PAGING_SIZE;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/servers/{serverId}/tags")
 public class HashTagController {
-    private HashTagFacade hashTagFacade;
+    private final HashTagFacade hashTagFacade;
 
     @GetMapping("")
     public ApiResponse<HashTagElements> findAll(

--- a/src/main/java/com/coastee/server/hashtag/domain/repository/HashTagRepository.java
+++ b/src/main/java/com/coastee/server/hashtag/domain/repository/HashTagRepository.java
@@ -26,4 +26,17 @@ public interface HashTagRepository extends JpaRepository<HashTag, Long> {
             @Param("server") final Server server,
             final Pageable pageable
     );
+
+    @Query("""
+            select h from ChatRoomTag t
+                    join HashTag h on t.hashTag = h
+                    join ChatRoom r on t.chatRoom = r and r.server = :server
+            group by h having h.content like concat('%', :keyword, '%')
+            order by count (h) desc
+            """)
+    Page<HashTag> findAllByContentContainingAndServer(
+            @Param("keyword") final String keyword,
+            @Param("server") final Server server,
+            final Pageable pageable
+    );
 }

--- a/src/main/java/com/coastee/server/hashtag/dto/HashTagElements.java
+++ b/src/main/java/com/coastee/server/hashtag/dto/HashTagElements.java
@@ -1,0 +1,25 @@
+package com.coastee.server.hashtag.dto;
+
+import com.coastee.server.global.domain.PageInfo;
+import com.coastee.server.hashtag.domain.HashTag;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+@AllArgsConstructor
+public class HashTagElements {
+    private PageInfo pageInfo;
+    private List<HashTagElement> hashTagList;
+
+    public HashTagElements(final Page<HashTag> hashTagPage) {
+        this.pageInfo = new PageInfo(hashTagPage);
+        this.hashTagList = hashTagPage.getContent().stream().map(HashTagElement::new).toList();
+    }
+}

--- a/src/main/java/com/coastee/server/hashtag/facade/HashTagFacade.java
+++ b/src/main/java/com/coastee/server/hashtag/facade/HashTagFacade.java
@@ -1,10 +1,12 @@
 package com.coastee.server.hashtag.facade;
 
+import com.coastee.server.hashtag.domain.HashTag;
 import com.coastee.server.hashtag.dto.HashTagElements;
 import com.coastee.server.hashtag.service.HashTagService;
 import com.coastee.server.server.domain.Server;
 import com.coastee.server.server.service.ServerService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,7 +24,7 @@ public class HashTagFacade {
             final Pageable pageable
     ) {
         Server server = serverService.findById(serverId);
-        hashTagService.findAllByKeyword(keyword);
-        return null;
+        Page<HashTag> hashTagPage = hashTagService.findAllByKeywordAndServer(keyword, server, pageable);
+        return new HashTagElements(hashTagPage);
     }
 }

--- a/src/main/java/com/coastee/server/hashtag/facade/HashTagFacade.java
+++ b/src/main/java/com/coastee/server/hashtag/facade/HashTagFacade.java
@@ -1,0 +1,28 @@
+package com.coastee.server.hashtag.facade;
+
+import com.coastee.server.hashtag.dto.HashTagElements;
+import com.coastee.server.hashtag.service.HashTagService;
+import com.coastee.server.server.domain.Server;
+import com.coastee.server.server.service.ServerService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class HashTagFacade {
+    private final HashTagService hashTagService;
+    private final ServerService serverService;
+
+    public HashTagElements findWithConditions(
+            final Long serverId,
+            final String keyword,
+            final Pageable pageable
+    ) {
+        Server server = serverService.findById(serverId);
+        hashTagService.findAllByKeyword(keyword);
+        return null;
+    }
+}

--- a/src/main/java/com/coastee/server/hashtag/service/HashTagService.java
+++ b/src/main/java/com/coastee/server/hashtag/service/HashTagService.java
@@ -30,14 +30,6 @@ public class HashTagService {
         connectTag(chatRoom, hashTagList);
     }
 
-    public List<HashTag> findPopularTagByServer(final Server server, final Pageable pageable) {
-        return hashTagRepository.findPopularTagByServer(server, pageable).getContent();
-    }
-
-    public List<HashTag> findAllByContentIn(final Set<String> tagNameSet) {
-        return hashTagRepository.findAllByContentIn(tagNameSet);
-    }
-
     private void connectTag(final ChatRoom chatRoom, final List<HashTag> hashTagList) {
         List<ChatRoomTag> chatRoomTagList = hashTagList.stream()
                 .map(tag -> new ChatRoomTag(chatRoom, tag))

--- a/src/main/java/com/coastee/server/hashtag/service/HashTagService.java
+++ b/src/main/java/com/coastee/server/hashtag/service/HashTagService.java
@@ -7,6 +7,7 @@ import com.coastee.server.hashtag.domain.HashTag;
 import com.coastee.server.hashtag.domain.repository.HashTagRepository;
 import com.coastee.server.server.domain.Server;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -57,5 +58,12 @@ public class HashTagService {
             newTags = hashTagRepository.saveAll(newTags);
         }
         return Stream.concat(existingTagList.stream(), newTags.stream()).toList();
+    }
+
+    public Page<HashTag> findAllByKeyword(
+            final String keyword,
+            final Pageable pageable
+    ) {
+        
     }
 }

--- a/src/main/java/com/coastee/server/hashtag/service/HashTagService.java
+++ b/src/main/java/com/coastee/server/hashtag/service/HashTagService.java
@@ -60,10 +60,14 @@ public class HashTagService {
         return Stream.concat(existingTagList.stream(), newTags.stream()).toList();
     }
 
-    public Page<HashTag> findAllByKeyword(
+    public Page<HashTag> findAllByKeywordAndServer(
             final String keyword,
+            final Server server,
             final Pageable pageable
     ) {
-        
+        if (keyword == null || keyword.isBlank()) {
+            return hashTagRepository.findPopularTagByServer(server, pageable);
+        }
+        return hashTagRepository.findAllByContentContainingAndServer(keyword, server, pageable);
     }
 }

--- a/src/main/java/com/coastee/server/server/facade/ServerFacade.java
+++ b/src/main/java/com/coastee/server/server/facade/ServerFacade.java
@@ -77,10 +77,11 @@ public class ServerFacade {
         Server server = serverService.findById(serverId);
         serverEntryService.validateJoin(user, server);
 
-        List<HashTag> hashTagList = hashTagService.findPopularTagByServer(
+        List<HashTag> hashTagList = hashTagService.findAllByKeywordAndServer(
+                keyword,
                 server,
                 PageRequest.of(0, 10)
-        );
+        ).getContent();
 
         Page<ChatRoom> groupPage = chatRoomService.findByServerAndTypeAndKeywordAndTagList(
                 server,

--- a/src/test/java/com/coastee/server/hashtag/controller/HashTagControllerTest.java
+++ b/src/test/java/com/coastee/server/hashtag/controller/HashTagControllerTest.java
@@ -24,8 +24,7 @@ import static org.springframework.restdocs.headers.HeaderDocumentation.requestHe
 import static org.springframework.restdocs.payload.JsonFieldType.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.restdocs.restassured.RestAssuredRestDocumentation.document;
 
 @DisplayName("해시태그 컨트롤러 테스트")
@@ -59,9 +58,12 @@ class HashTagControllerTest extends ControllerTest {
                 .param("page", "0")
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .filter(
-                        document("find-all-dmroom",
+                        document("find-hashtag",
                                 queryParameters(
                                         parameterWithName("page").description("페이지 번호 (default: 0)")
+                                ),
+                                pathParameters(
+                                        parameterWithName("serverId").description("서버 아이디")
                                 ),
                                 requestHeaders(
                                         headerWithName(ACCESS_TOKEN_HEADER).description("액세스 토큰")
@@ -76,12 +78,12 @@ class HashTagControllerTest extends ControllerTest {
                                         fieldWithPath("result.pageInfo.totalPages").type(NUMBER).description("총 페이지 개수"),
                                         fieldWithPath("result.pageInfo.totalElements").type(NUMBER).description("총 요소 개수"),
                                         fieldWithPath("result.pageInfo.size").type(NUMBER).description("페이지 사이즈"),
-                                        fieldWithPath("result.hashTagList").type(ARRAY).description("DM방 리스트"),
+                                        fieldWithPath("result.hashTagList").type(ARRAY).description("해시태그 리스트"),
                                         fieldWithPath("result.hashTagList[].id").type(NUMBER).description("아이디"),
-                                        fieldWithPath("result.hashTagList[].content").type(OBJECT).description("나와 dm을 나눈 유저")
+                                        fieldWithPath("result.hashTagList[].content").type(STRING).description("해시태그 내용")
                                 )
                         ))
-                .when().get("/api/v1/dms")
+                .when().get("/api/v1/servers/{serverId}/tags", 1)
                 .then().log().all().statusCode(200);
     }
 }

--- a/src/test/java/com/coastee/server/hashtag/controller/HashTagControllerTest.java
+++ b/src/test/java/com/coastee/server/hashtag/controller/HashTagControllerTest.java
@@ -1,0 +1,87 @@
+package com.coastee.server.hashtag.controller;
+
+import com.coastee.server.fixture.HashTagFixture;
+import com.coastee.server.global.domain.PageInfo;
+import com.coastee.server.hashtag.domain.HashTag;
+import com.coastee.server.hashtag.domain.repository.HashTagRepository;
+import com.coastee.server.hashtag.dto.HashTagElement;
+import com.coastee.server.hashtag.dto.HashTagElements;
+import com.coastee.server.hashtag.facade.HashTagFacade;
+import com.coastee.server.util.ControllerTest;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.payload.JsonFieldType.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.restdocs.restassured.RestAssuredRestDocumentation.document;
+
+@DisplayName("해시태그 컨트롤러 테스트")
+class HashTagControllerTest extends ControllerTest {
+
+    @MockitoBean
+    private HashTagFacade hashTagFacade;
+
+    @Autowired
+    private HashTagRepository hashTagRepository;
+
+    @DisplayName("해시태그가 검색된다.")
+    @Test
+    void findAll() throws Exception {
+        // given
+        List<HashTag> hashTagList = hashTagRepository
+                .saveAll(HashTagFixture.getAll());
+
+        // when
+        when(hashTagFacade.findWithConditions(any(), any(), any()))
+                .thenReturn(
+                        new HashTagElements(
+                                new PageInfo(true, 0, 3, 40),
+                                hashTagList.stream().map(HashTagElement::new).toList()
+                        )
+                );
+
+        // then
+        RestAssured.given(spec).log().all()
+                .header(ACCESS_TOKEN_HEADER, ACCESS_TOKEN)
+                .param("page", "0")
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .filter(
+                        document("find-all-dmroom",
+                                queryParameters(
+                                        parameterWithName("page").description("페이지 번호 (default: 0)")
+                                ),
+                                requestHeaders(
+                                        headerWithName(ACCESS_TOKEN_HEADER).description("액세스 토큰")
+                                ),
+                                responseFields(
+                                        fieldWithPath("isSuccess").type(BOOLEAN).description("성공 여부"),
+                                        fieldWithPath("code").type(STRING).description("결과 코드"),
+                                        fieldWithPath("message").type(STRING).description("결과 메세지"),
+                                        fieldWithPath("result").type(OBJECT).description("결과 데이터"),
+                                        fieldWithPath("result.pageInfo").type(OBJECT).description("페이징 정보"),
+                                        fieldWithPath("result.pageInfo.lastPage").type(BOOLEAN).description("마지막 페이지 여부"),
+                                        fieldWithPath("result.pageInfo.totalPages").type(NUMBER).description("총 페이지 개수"),
+                                        fieldWithPath("result.pageInfo.totalElements").type(NUMBER).description("총 요소 개수"),
+                                        fieldWithPath("result.pageInfo.size").type(NUMBER).description("페이지 사이즈"),
+                                        fieldWithPath("result.hashTagList").type(ARRAY).description("DM방 리스트"),
+                                        fieldWithPath("result.hashTagList[].id").type(NUMBER).description("아이디"),
+                                        fieldWithPath("result.hashTagList[].content").type(OBJECT).description("나와 dm을 나눈 유저")
+                                )
+                        ))
+                .when().get("/api/v1/dms")
+                .then().log().all().statusCode(200);
+    }
+}


### PR DESCRIPTION
## 📒 개요

해시태그 검색 API 입니다.

## 📍 Issue 번호

- #89 

## 🛠️ 작업사항

- [x] 해시태그 검색 api
- [x] 서버 내 검색시 해시태그에도 필터링 결과 반영
